### PR TITLE
Grafana plugin: mention how to load unsigned plugin

### DIFF
--- a/content/reference/current/plugins/grafana/index.md
+++ b/content/reference/current/plugins/grafana/index.md
@@ -23,6 +23,13 @@ You can install it using the grafana-cli:
 
 `grafana-cli --pluginUrl GRAFANA_DATASOURCE_BUNDLE_URL plugins install frontline`
 
+Please note that the plugin is unsigned, and may recent versions of Grafana may reject it. In this case, [you need to add the plugin to the list of allowed unsigned plugin](https://grafana.com/docs/grafana/latest/administration/configuration/#allow_loading_unsigned_plugins).
+
+Grafana configuration sample:
+```
+allow_loading_unsigned_plugins = frontline
+```
+
 ## Adding the datasource
 
 - In the Grafana side menu you will find the `Data Sources` link under `Configuration` (link name may depend on the grafana version).


### PR DESCRIPTION
Motivation:
- recent versions of Grafana don't allow unisgned plugins

Modifications:
- added a link documenting how to allow unisnged plugin