### PR TITLE
Update external plugins link to current version

### DIFF
--- a/content/reference/current/_index.md
+++ b/content/reference/current/_index.md
@@ -13,4 +13,5 @@ cascade:
     gatlingSbtPluginVersion: "3.2.2"
     frontLineSbtPluginVersion: "1.3.2"
     frontLineGradlePluginVersion: "1.4.0"
+    externalPluginsVersion: "1.14.2"
 ---

--- a/content/reference/current/plugins/bamboo/index.md
+++ b/content/reference/current/plugins/bamboo/index.md
@@ -18,7 +18,7 @@ This plugin doesn't create a new Gatling Enterprise simulation, you have to crea
 To download the plugin, you need to get the jar file located at:
 
 ```
-https://downloads.gatling.io/releases/frontline-bamboo-plugin/1.13.3/frontline-bamboo-plugin-1.13.3.jar
+https://downloads.gatling.io/releases/frontline-bamboo-plugin/{{< var externalPluginsVersion >}}/frontline-bamboo-plugin-{{< var externalPluginsVersion >}}.jar
 ```
 
 You need to be connected as an administrator of your Bamboo application to install it. Go *Bamboo Administration*, *Manage Apps*, *Upload app*, and choose the jar file.

--- a/content/reference/current/plugins/grafana/index.md
+++ b/content/reference/current/plugins/grafana/index.md
@@ -16,7 +16,7 @@ Download and install [Grafana](http://grafana.org/download/).
 The Gatling Enterprise datasource for Grafana is packaged as a zip bundle that you can found at this URL:
 
 ```
-https://downloads.gatling.io/releases/frontline-grafana-bundle/1.13.3/frontline-grafana-bundle-1.13.3-bundle.zip
+https://downloads.gatling.io/releases/frontline-grafana-bundle/{{< var externalPluginsVersion >}}/frontline-grafana-bundle-{{< var externalPluginsVersion >}}-bundle.zip
 ```
 
 You can install it using the grafana-cli:

--- a/content/reference/current/plugins/jenkins/index.md
+++ b/content/reference/current/plugins/jenkins/index.md
@@ -18,7 +18,7 @@ This plugin doesn't create a new Gatling Enterprise simulation, you have to crea
 To download the plugin, you need to get the hpi file located at:
 
 ```
-https://downloads.gatling.io/releases/frontline-jenkins-plugin/1.13.3/frontline-jenkins-plugin-1.13.3.hpi
+https://downloads.gatling.io/releases/frontline-jenkins-plugin/{{< var externalPluginsVersion >}}/frontline-jenkins-plugin-{{< var externalPluginsVersion >}}.hpi
 ```
 
 You need to be connected as an administrator of your Jenkins application to install it. Go **Manage Jenkins**, **Manage Plugins**, **Advanced**, **Upload Plugin**, and choose the hpi file.


### PR DESCRIPTION
Motivation:
- ci plugins and grafana datasource were still linking an old version: 1.13.3

Modification:
- added a constant with the version of the plugins
- use the constant in jenkins, bamboo, teamcity, script and grafana doc