### PR TITLE
Enrich documentation about how to get the repository url, close MISC-266

### DIFF
--- a/content/reference/current/installation/ansible/index.md
+++ b/content/reference/current/installation/ansible/index.md
@@ -59,8 +59,12 @@ If you need to specify a proxy for the remote machine on which Gatling Enterpris
 You can download the installer here:
 
 ```
-REPLACE_WITH_YOUR_REPOSITORY_URL/frontline-installer/REPLACE_WITH_LATEST_FRONTLINE_VERSION/frontline-installer-REPLACE_WITH_LATEST_FRONTLINE_VERSION.zip
+REPLACE_WITH_YOUR_REPOSITORY_URL/frontline-installer/{{< var revnumber >}}/frontline-installer-{{< var revnumber >}}.zip
 ```
+
+{{< alert tip >}}
+Check the [documentation conventions]({{< ref "../introduction#repository-url" >}}) for ways to find your repository URL.
+{{< /alert >}}
 
 We suggest you download and check the integrity of the installer by doing the following:
 

--- a/content/reference/current/installation/introduction/index.md
+++ b/content/reference/current/installation/introduction/index.md
@@ -27,14 +27,16 @@ Gatling Enterprise consists of:
   * Continuous Integration plugins for Jenkins, Bamboo and TeamCity or any solution that can trigger a bash script
 - Gatling injectors to be used like standard Gatling OSS, with extra features so Gatling Enterprise can collect data from them
 
-## Document Conventions
+## Documentation Conventions
 
-In this document, you'll find several mentions to some placeholders in capital letters.
+In this documentation, you'll find several mentions to some placeholders in capital letters.
 
-- REPLACE_WITH_YOUR_REPOSITORY_URL: the URL of the private repository that you were given alongside with your license key
+### Repository URL
+
+Any references to private urls were removed from this documentation and replaced with the placeholder `REPLACE_WITH_YOUR_REPOSITORY_URL`. It represents the URL of the private repository you were given along with your license key.
+
+This repository URL was shared by our sales persons with the manager in charge of the contract and the administrators registered for support.
 
 {{< alert warning >}}
-This placeholder only makes sense for on premise customers. AWS Marketplace customers spawn a pre-installed AMI and already have all the dependencies they need.
+This placeholder only makes sense for self-hosted customers. AWS and Azure Marketplace customers spawn a pre-installed virtual machine and already have all the dependencies they need.
 {{< /alert >}}
-
-- REPLACE_WITH_LATEST_FRONTLINE_VERSION: {{< var revnumber >}} at the time this document was edited

--- a/content/reference/current/installation/manual/index.md
+++ b/content/reference/current/installation/manual/index.md
@@ -191,8 +191,12 @@ Second method implies (as stated in Cassandra documentation) to add instances wi
 Gatling Enterprise is packaged as a zip bundle that can be downloaded from our maven repository (only for on-premise customers):
 
 ```
-REPLACE_WITH_YOUR_REPOSITORY_URL/frontline-bundle/REPLACE_WITH_LATEST_FRONTLINE_VERSION/frontline-bundle-REPLACE_WITH_LATEST_FRONTLINE_VERSION-bundle.zip
+REPLACE_WITH_YOUR_REPOSITORY_URL/frontline-bundle/{{< var revnumber >}}/frontline-bundle-{{< var revnumber >}}-bundle.zip
 ```
+
+{{< alert tip >}}
+Check the [documentation conventions]({{< ref "../introduction#repository-url" >}}) for ways to find your repository URL.
+{{< /alert >}}
 
 On launch, Gatling Enterprise will create or update the Gatling Enterprise schema in the Cassandra database.
 


### PR DESCRIPTION
Motivation:

- Remind users how to get their repository url
- Profit to remove occurrences of latest version and directly bake in the latest
  version