### PR TITLE
fix: Properly document the new config style for Cassandra

### DIFF
--- a/content/reference/current/installation/configuration/includes/frontline.conf
+++ b/content/reference/current/installation/configuration/includes/frontline.conf
@@ -24,24 +24,34 @@ frontline {
     #superAdminPassword = DO_NOT_EDIT_FRONTLINE_WILL_REPLACE_THIS
     #secretKey = DO_NOT_EDIT_FRONTLINE_WILL_REPLACE_THIS
   }
+  cassandra-defaults {
+    host = 127.0.0.1
+    host = ${?FRONTLINE_CASSANDRA_HOST}
+    port = 9042
+    port = ${?FRONTLINE_CASSANDRA_PORT}
+    contact-point = ${frontline.cassandra-defaults.host}":"${frontline.cassandra-defaults.port}
+    contact-point = ${?FRONTLINE_CASSANDRA_CONTACT_POINT}
+  }
   cassandra {
-    localDataCenter = datacenter1
-    contactPoints = [{
-      host = localhost
-      host = ${?FRONTLINE_CASSANDRA_HOST}
-      port = 9042
-      port = ${?FRONTLINE_CASSANDRA_PORT}
-    }]
-    keyspace = gatling
+    # Gatling-specific configuration keys:
+    gatling-keyspace = gatling
     replication = "{'class':'SimpleStrategy', 'replication_factor': 1}"
-    credentials {
-      #username = "hello"
-      #password = "world"
-    }
     runsCleanup {
       #maxRunsBySimulation = 30
       #maxRunAge = 100
       #timeOfDay = "15:10"
+    }
+
+    # All other configuration keys are standard keys from the Cassandra Java driver.
+    # See the reference configuration file:
+    # https://github.com/datastax/java-driver/blob/4.x/core/src/main/resources/reference.conf
+    basic {
+      contact-points.0 = ${frontline.cassandra-defaults.contact-point}
+      load-balancing-policy.local-datacenter = datacenter1
+    }
+    advanced.auth-provider {
+      #username = "hello"
+      #password = "world"
     }
   }
   grafana {

--- a/content/reference/current/installation/configuration/index.md
+++ b/content/reference/current/installation/configuration/index.md
@@ -24,3 +24,10 @@ Click on the "Next" button to finish the configuration step and restart Gatling 
 Find below the default `frontline.conf` file:
 
 {{< include-code "frontline.conf" hocon >}}
+
+{{< alert warning >}}
+Since 1.14.0, the `frontline.cassandra` configuration object uses the standard configuration keys from the Cassandra
+Java driver (except for `gatling-keyspace`, `replication` and `runsCleanup`). The previous configuration keys (now
+deprecated) are still supported for backward compatibility, but the two configuration styles are not compatible with
+each other. We recommend fully migrating to the new style.
+{{< /alert >}}

--- a/content/reference/current/release/release-notes/index.md
+++ b/content/reference/current/release/release-notes/index.md
@@ -229,7 +229,7 @@ This release doesn't perform any new database automatic migration if you're upgr
 * FL-396: Repository: Gatling zip bundle now ships a script to generate uploadable artifacts (eg in an S3 bucket repository)
 * FL-474: Pools: Add nonProxyHosts option for HTTP proxy configuration
 * FL-534: AWS: subnets are no multivalued and retried randomly if deploying the pool fails for insufficient capacity
-* FL-589: Cassandra: Expose full Cassandra Java Driver configuration with Typesafe config (eg configuring TSL)
+* FL-589: Cassandra: Expose full Cassandra Java Driver configuration with Typesafe config (eg configuring TLS)
 
 #### Fixes
 


### PR DESCRIPTION
ref: MISC-334
ref: MISC-339

Motivation:

The config sample isn't correct for the new Cassandra config style. We also don't warn against mixing and matching with deprecated keys.

Modifications:

- Fix the sample config file
- Add a warning about the deprecated Cassandra config style