### PR TITLE
chore: Add documentation for building with Maven or Gradle wrapper

### DIFF
--- a/content/reference/current/installation/manual/index.md
+++ b/content/reference/current/installation/manual/index.md
@@ -523,6 +523,8 @@ then Gatling Enterprise needs to be able to build the fetched resources, ie:
 
 Make sure that the build tool is configured so that it is able to download artifacts, typically if your organization enforces repository mirrors.
 
+Alternatively, if your projects include a build tool wrapper such as [Maven wrapper](https://maven.apache.org/wrapper/) (`mvnw`) or [Gradle Wrapper](https://docs.gradle.org/current/userguide/gradle_wrapper.html) (`gradlew`), then you don't need to install a build tool client. However, you must make sure the build tool wrapper script is able to download all its dependencies when running on the Gatling Enterprise host. 
+
 {{< alert tip >}}
 Maven 3.3.9 is the minimal version supported. This is the version shipped in Debian 9 (Stretch).
 {{< /alert >}}

--- a/content/reference/current/user/simulations/index.md
+++ b/content/reference/current/user/simulations/index.md
@@ -78,9 +78,14 @@ In this step, Gatling Enterprise will download the sources from your repository,
   * `sbt -J-Xss100M ;clean;test:assembly -batch --error` for sbt project
   * `gradle clean frontLineJar -quiet` for gradle project
 
-{{< alert warning >}}
-Please make sure that the tools you are using are installed and available on the Gatling Enterprise machine, for example: `mvn`,  `sbt`, `git`, and `ssh`.
-{{< /alert >}}
+  {{< alert warning >}}
+  Please make sure that the tools you are using are installed and available on the Gatling Enterprise machine, for example: `mvn`,  `sbt`, `git`, and `ssh`.
+  {{< /alert >}}
+
+  In addition, two wrapper commands are built-in, if you prefer to use a build tool wrapper script included in your project rather than a version of the build tool installed on the Gatling Enterprise machine. The commands are otherwise the same as the regular commands for the same build tools.
+  * Use the Maven Wrapper command if your project includes an `mvnw` script (see [the official Maven documentation](https://maven.apache.org/wrapper/) to configure your project)
+  * Use the Gradle Wrapper command if your project includes a `gradlew` script (see [the official Gradle documentation](https://docs.gradle.org/current/userguide/gradle_wrapper.html) to configure your project)
+
 
 You can provide optional settings if you toggle **Advanced build configuration**.
 


### PR DESCRIPTION
See also gatling/frontline#1542

-----

Motivation:

We offer the option to build from sources with Maven Wrapper (mvnw) or Gradle wrapper (gradlew) but don't mention it in the documentation.

Modifications:

- Mention the two wrapper options in the build section of the simulation doc
- Mention the two wrappers in the build tool clients section of the manual installation doc