### PR TITLE
fix: Mention UID change impact for Docker users in 1.18.3 release notes

### DIFF
--- a/content/reference/current/release/release-notes/index.md
+++ b/content/reference/current/release/release-notes/index.md
@@ -8,6 +8,14 @@ weight: 6010
 
 ## 1.18.3 (2023-04-03)
 
+{{< alert warning >}}
+**If you run the Gatling Enterprise server in Docker (including Kubernetes) with the default user**: you will need to change the owner of your private key files. This is because the default user for the `gatlingcorp/frontline` container is no longer the root user (it now defaults to the uid:gid `1001:0`).
+
+- If you already explicitly override the user (e.g. by using the `user` key in Docker Compose, or the `runAsUser` directive in Kubernetes), you have nothing to do.
+- If you run Gatling Enterprise on OpenShift with the default user settings, you have nothing to do (OpenShift already overrides the user by default).
+- Otherwise, you need to change the ownership of your private key files (mounted to `/opt/frontline/keys` in the container): `chown 1001:0 <my_private_key_file>`
+{{< /alert >}}
+
 ### Gatling 3.9.3
 
 Please check the [full release](https://github.com/gatling/gatling/milestone/115?closed=1) note for more details.


### PR DESCRIPTION
Motivation:

- We changed the default user in the Docker container
- Private key files are typically only readable by their owner

Modifications:

Add a warning in the release notes.

Result:

Users who run Gatling Enterprise Self-Hosted in Docker can upgrade more easily.