### PR TITLE
chore: finer logging example in kubernetes configuration

### DIFF
--- a/content/reference/current/installation/kubernetes/index.md
+++ b/content/reference/current/installation/kubernetes/index.md
@@ -3,7 +3,7 @@ title: "Installation with Kubernetes"
 description: "Learn how to install Gatling Enterprise with Kubernetes"
 lead: "Install Gatling Enterprise and Cassandra easily with Kubernetes"
 date: 2021-03-26T17:37:11+01:00
-lastmod: 2023-04-03T12:00:00+00:00
+lastmod: 2023-10-12T08:44:13+00:00
 weight: 1050
 ---
 
@@ -88,7 +88,8 @@ data:
         </encoder>
         <immediateFlush>false</immediateFlush>
       </appender>
-      <root level="INFO">
+      <logger name="io.gatling.frontline" level="INFO"/>
+      <root level="WARN">
         <appender-ref ref="CONSOLE"/>
       </root>
     </configuration>


### PR DESCRIPTION
Motivation:

- Sample logback configuration uses INFO level on root, which is a bit much logging

Modification:

- Reduce it to WARN
- Put `io.gatling.frontline` under the INFO level